### PR TITLE
TEL-2662: force use of user 1000 (which is logstash user)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM logstash:7.16.3 AS logstash
 
+USER 1000
+
 RUN bin/logstash-plugin install logstash-input-kinesis
 
 COPY config /etc/logstash
 COPY pipeline /usr/share/logstash/pipeline
 
-RUN chown -R logstash:logstash /usr/share/logstash/ && \
-    chown -R logstash:logstash /etc/logstash/
+RUN chown -R logstash:logstash /etc/logstash/


### PR DESCRIPTION
* running chown failed on the pipeline YAML for some reason?

Co-authored-by: Paul Marsh <61422343+PTMGitHub@users.noreply.github.com>
