### PR TITLE
INFRA-7403: Allow the logstash image to be updated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM docker.elastic.co/logstash/logstash:7.16.3 AS logstash
+ARG LOGSTASH_VERSION
+FROM docker.elastic.co/logstash/logstash:${LOGSTASH_VERSION} AS logstash
 
 RUN bin/logstash-plugin install logstash-input-kinesis
 
@@ -6,3 +7,7 @@ RUN rm -f /usr/share/logstash/pipeline/logstash.conf
 
 COPY --chown=1000:1000 pipeline /usr/share/logstash/pipeline
 COPY --chown=1000:1000 scripts /usr/share/logstash/scripts
+
+# Telemetry confirmed that Logstash pipelines are not in use
+# This is set to avoid a startup warning
+ENV PIPELINE_ECS_COMPATIBILITY "disabled"

--- a/pipeline/99_output.conf
+++ b/pipeline/99_output.conf
@@ -28,8 +28,6 @@ output {
       codec => json
       max_request_size => 5242880
       topic_id => "logs"
-      ssl_truststore_location => "/etc/pki/java/cacerts"
-      ssl_truststore_password => "changeit"
       security_protocol => "SSL"
     }
   }


### PR DESCRIPTION
This allows the logstash image to be updated within a major version.
Elastic does not tag logstash with major versions so we use the Docker Hub API to get the latest relevant version.

In our case, Telemetry only use Logstash v7, so we search Docker Hub for images tagged with 7., filter and sort the results.