### PR TITLE
live_support_07_05_2026. Increase logstash JVM mem args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 ARG LOGSTASH_VERSION
 FROM docker.elastic.co/logstash/logstash:${LOGSTASH_VERSION}
 ENV PIPELINE_ECS_COMPATIBILITY=disabled
+ENV LS_JAVA_OPTS="-Xms4g -Xmx4g"
 
 RUN rm -f /usr/share/logstash/pipeline/logstash.conf
 


### PR DESCRIPTION
Kinesis Log Forwarder has been throwing "java.lang.OutOfMemoryError: Java heap space" errors. 
The JVM is running with default config of 1gb memory for the JVM. We have 16gb available in the container so this PR is to bump up the jvm memory to 4gb
